### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Connect this [Model Context Protocol](https://modelcontextprotocol.io/introducti
 
 It supports all the APIs available from the [Todoist TypeScript Client](https://doist.github.io/todoist-api-typescript/api/classes/TodoistApi/).
 
+<a href="https://glama.ai/mcp/servers/2010u29g1w">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/2010u29g1w/badge" alt="Todoist MCP server" />
+</a>
+
 ### Setup
 
 ### Installing via Smithery


### PR DESCRIPTION
This PR adds a badge for the [Todoist MCP](https://glama.ai/mcp/servers/2010u29g1w) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/2010u29g1w">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/2010u29g1w/badge" alt="Todoist MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.